### PR TITLE
fix: Resolve startup warnings and errors

### DIFF
--- a/trading_bot/data_fetcher/fetcher.py
+++ b/trading_bot/data_fetcher/fetcher.py
@@ -12,7 +12,7 @@ class DataFetcher:
     def _map_interval_str_to_api_const(self, interval_str):
         # Mapping from settings string to python-binance AsyncClient constants
         mapping = {
-            "1s": AsyncClient.KLINE_INTERVAL_1SECOND, # Added 1s for completeness, though WS might use it directly
+            # "1s": AsyncClient.KLINE_INTERVAL_1SECOND, # Typically not available for historical bulk fetch / may cause issues. WebSocket uses direct string for 1s.
             "1m": AsyncClient.KLINE_INTERVAL_1MINUTE,
             "3m": AsyncClient.KLINE_INTERVAL_3MINUTE,
             "5m": AsyncClient.KLINE_INTERVAL_5MINUTE,

--- a/trading_bot/strategy/gold_strategy.py
+++ b/trading_bot/strategy/gold_strategy.py
@@ -28,7 +28,13 @@ class GoldenStrategy:
         self.strategy_timeframe_str = settings.STRATEGY_TIMEFRAME
         # Ensure 'min' is used for 'T' if that's what pandas Timedelta expects for minute.
         # Pandas Timedelta is quite flexible: '1T' or '1min' for minute, '1H' for hour.
-        self.timeframe_delta = pd.Timedelta(self.strategy_timeframe_str.replace('T', 'min'))
+        # self.timeframe_delta = pd.Timedelta(self.strategy_timeframe_str.replace('T', 'min'))
+        # More robust timedelta string creation:
+        td_str = self.strategy_timeframe_str.lower()
+        if 't' in td_str and not 'min' in td_str: # For minute timeframes like '15T' -> '15min'
+            td_str = td_str.replace('t', 'min')
+        # 'h' for hours is already handled by .lower() if input was 'H'
+        self.timeframe_delta = pd.Timedelta(td_str)
 
         # Max length for aggregated klines (e.g., 100 bars of 1H data = 100 hours)
         # This should be based on indicator needs on aggregated data.


### PR DESCRIPTION
This commit addresses two issues identified from error logs that prevented the application from starting correctly:

1.  **FutureWarning in Timedelta Creation (`strategy/gold_strategy.py`):**
    *   Modified the creation of `pd.Timedelta` from `settings.STRATEGY_TIMEFRAME`.
    *   The timeframe string is now processed using `.lower()` and a specific replacement of 't' to 'min' (e.g., "1H" becomes "1h", "15T" becomes "15min") to ensure compatibility and resolve the `FutureWarning: 'H' is deprecated... Please use 'h' instead`.

2.  **AttributeError for KLINE_INTERVAL_1SECOND (`data_fetcher/fetcher.py`):**
    *   Removed the mapping for "1s" to `AsyncClient.KLINE_INTERVAL_1SECOND` from the `_map_interval_str_to_api_const` method.
    *   This specific constant name caused an `AttributeError` on startup. The application defaults to "1m" for data fetching as per `settings.KLINE_FETCH_INTERVAL`, and the "1s" mapping is not essential for this configuration and was causing a crash.

These changes should allow the application to initialize and run without the previously reported startup errors.