### PR TITLE
fix: Resolve critical startup errors and TimeDelta warnings

### DIFF
--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -64,12 +64,18 @@ class BotApplication:
             # Ensure client is initialized in fetcher before calling fetch_historical_klines
             # The fetch_historical_klines method now handles client initialization.
 
-            strategy_tf_str = settings.STRATEGY_TIMEFRAME.replace('T', 'min') # For Timedelta
-            fetch_interval_str = settings.KLINE_FETCH_INTERVAL.replace('m', 'min') # Assuming 'm' for minutes
+            # Process timeframe strings for pd.Timedelta compatibility
+            processed_strategy_tf_str = settings.STRATEGY_TIMEFRAME.lower()
+            if 't' in processed_strategy_tf_str and not 'min' in processed_strategy_tf_str:
+                processed_strategy_tf_str = processed_strategy_tf_str.replace('t', 'min')
+            strategy_tf_delta = pd.Timedelta(processed_strategy_tf_str)
 
-            strategy_tf_delta = pd.Timedelta(strategy_tf_str)
-            fetch_interval_delta = pd.Timedelta(fetch_interval_str)
-
+            processed_fetch_interval_str = settings.KLINE_FETCH_INTERVAL.lower()
+            if 'm' in processed_fetch_interval_str and not 'min' in processed_fetch_interval_str and 'ms' not in processed_fetch_interval_str:
+                processed_fetch_interval_str = processed_fetch_interval_str.replace('m', 'min')
+            elif 's' in processed_fetch_interval_str and not 'sec' in processed_fetch_interval_str and 'ms' not in processed_fetch_interval_str:
+                processed_fetch_interval_str = processed_fetch_interval_str.replace('s', 'sec')
+            fetch_interval_delta = pd.Timedelta(processed_fetch_interval_str)
 
             if strategy_tf_delta < fetch_interval_delta:
                 logger.error(f"Strategy timeframe {settings.STRATEGY_TIMEFRAME} cannot be smaller than fetch interval {settings.KLINE_FETCH_INTERVAL}.")


### PR DESCRIPTION
This commit addresses two key issues that were preventing the application from starting and running correctly:

1.  **TypeError in DataFetcher (`data_fetcher/fetcher.py`):**
    *   Corrected the calls to `AsyncClient.get_historical_klines` within the `fetch_historical_klines` method by removing the `endtime` keyword argument, which is not a valid parameter for this library function and was causing a `TypeError`.
    *   The `end_time_ms` parameter was also removed from the `fetch_historical_klines` method signature as it was unused by the calling code in `main.py` and contributed to the incorrect `endtime` usage.
    *   This fix allows the historical data fetching process to execute correctly.

2.  **FutureWarning for pd.Timedelta in `main.py`:**
    *   Ensured that timeframe strings sourced from `settings.STRATEGY_TIMEFRAME` and `settings.KLINE_FETCH_INTERVAL` are robustly processed (converted to lowercase, 'T' to 'min', 'm' to 'min', 's' to 'sec' as appropriate) before being passed to `pd.Timedelta`.
    *   This resolves the `FutureWarning: 'H' is deprecated... Please use 'h' instead` that was occurring in `main.py` during the calculation of time deltas for historical lookback. A similar fix was previously applied to `gold_strategy.py`.

These changes ensure that the application initializes without these specific errors, allowing the historical data pre-fill and subsequent live operations to proceed as intended.