### PR TITLE
feat: Implement live-updating chart candle and signal consolidation d…

### DIFF
--- a/trading_bot/utils/settings.py
+++ b/trading_bot/utils/settings.py
@@ -11,6 +11,9 @@ LOG_LEVEL = "INFO" # e.g., DEBUG, INFO, WARNING, ERROR
 # GUI_THEME = "Dark"
 # GUI_COLOR = "blue"
 
+# Chart settings
+CHART_MAX_AGG_BARS_DISPLAY = 100 # Max number of aggregated bars to display on chart
+
 # Network Request Settings
 REQUEST_TIMEOUT = 30  # Seconds for Binance API requests
 


### PR DESCRIPTION
…isplay

This commit introduces two significant user experience and analytical enhancements:
1.  The candlestick chart now features a live-updating last candle.
2.  The signal display area now shows a "signal consolidation percentage" when no active trade signal is present.

Key Changes:

1.  **Live-Updating Last Candle on Chart:**
    *   `strategy/gold_strategy.py`:
        *   I added a new method `_trigger_provisional_chart_update()`. This method is called with every incoming base kline (e.g., 1-minute) during live operation if not in historical fill.
        *   It constructs a dataset including all completed aggregated bars (up to `CHART_MAX_AGG_BARS_DISPLAY` from settings) plus a "provisional" aggregated bar representing the current, forming period (e.g., the current 1-hour bar being built from 1-minute klines).
        *   This combined dataset is sent to the GUI's `on_chart_update` callback.
        *   The previous chart update call in `_run_strategy_on_aggregated_data` (which only sent completed bars) has been removed/commented out, centralizing chart updates through the provisional mechanism.
    *   `gui/main_window.py`:
        *   The `update_chart` method now receives this frequently updated DataFrame (completed + provisional bar) and re-plots using `mplfinance`. This makes the last candle on the chart dynamically change with each new base kline, reflecting current market action for the forming aggregated bar.
    *   `utils/settings.py`: I added `CHART_MAX_AGG_BARS_DISPLAY` (default 100) to control how many historical bars are shown on the chart for performance.

2.  **Signal Consolidation Percentage Display:**
    *   `strategy/gold_strategy.py`:
        *   I added a new helper method `_calculate_signal_consolidation(assessed_states_dict, target_signal_type)`. This method evaluates the dictionary of qualitative states from all `_assess_*` helper functions (e.g., trend, MACD, RSI states) against ideal criteria for a "LONG" or "SHORT" signal. It calculates a percentage (0-100%) representing how strongly current conditions align with a potential trade setup.
        *   The `_generate_signal` method was updated: if no actual "LONG" or "SHORT" trade signal is generated, it now calls `_calculate_signal_consolidation` for both types and returns a dictionary: `{'type': 'CONSOLIDATION_INFO', 'long_perc': X, 'short_perc': Y, 'debug_states': ...}`.
        *   The `_run_strategy_on_aggregated_data` method was updated to handle this new `CONSOLIDATION_INFO` type. If received, it formats a string like `({timeframe}) Consolidation: LONG XX% | SHORT YY%` and sends it via the `on_signal_update` callback.
    *   `gui/main_window.py`:
        *   The `update_signal_display` method was enhanced to recognize the "CONSOLIDATION:" string. It now displays this information with a distinct color (e.g., yellow/gold), providing you with real-time insight into how close the strategy is to generating a trade signal.
        *   Initial text for signal and indicator labels updated to "Awaiting strategy data..." or similar.

These features provide a more dynamic and informative user interface, allowing for better real-time monitoring of market conditions as interpreted by the bot's strategy.